### PR TITLE
Add repo ref to example

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -14,7 +14,7 @@ Omitting that parameter will install the latest released version.
 
 ```
       - name: Install
-        uses: pandoc/actions/setup
+        uses: pandoc/actions/setup@{main}
         with:
           version: 2.19
 


### PR DESCRIPTION
As described in the [docs](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#adding-an-action-from-a-different-repository) in addition to the repository owner and the repository name a specific reference has to be declared.